### PR TITLE
use unpatched socket module to get addresses

### DIFF
--- a/os_win/_utils.py
+++ b/os_win/_utils.py
@@ -16,7 +16,6 @@
 
 import netaddr
 import six
-import socket
 import time
 import types
 
@@ -32,7 +31,7 @@ from os_win._i18n import _LE
 
 LOG = logging.getLogger(__name__)
 
-
+socket = eventlet.import_patched('socket')
 synchronized = lockutils.synchronized_with_prefix('oswin-')
 
 

--- a/os_win/tests/unit/test_utils.py
+++ b/os_win/tests/unit/test_utils.py
@@ -187,7 +187,7 @@ class UtilsTestCase(base.BaseTestCase):
         self.assertEqual(1, mock_side_effect.call_count)
         self.assertFalse(mock_sleep.called)
 
-    @mock.patch('socket.getaddrinfo')
+    @mock.patch.object(_utils.socket, 'getaddrinfo')
     def test_get_ips(self, mock_getaddrinfo):
         ips = ['1.2.3.4', '5.6.7.8']
         mock_getaddrinfo.return_value = [


### PR DESCRIPTION
The function os_win._utils.get_ips can fail on some
environments if the socket module is monkey patched by
eventlet. Using the unpatched module fixes the issue.

Change-Id: Ib145f5b216d39d1e49231522f7d32d1ec2c63272