### PR TITLE
Fix cluster group migration status checks

### DIFF
--- a/os_win/exceptions.py
+++ b/os_win/exceptions.py
@@ -191,8 +191,36 @@ class ClusterWin32Exception(ClusterException, Win32Exception):
     pass
 
 
+# TODO(lpetrut): Remove this exception in Q. It was never used outside
+# os-win.
 class InvalidClusterGroupState(ClusterException):
     msg_fmt = _("The cluster group %(group_name)s is in an invalid state. "
                 "Expected state %(expected_state)s. Expected owner node: "
                 "%(expected_node)s. Current group state: %(group_state)s. "
                 "Current owner node: %(owner_node)s.")
+
+
+class ClusterGroupMigrationFailed(ClusterException):
+    msg_fmt = _("Failed to migrate cluster group %(group_name)s. "
+                "Expected state %(expected_state)s. "
+                "Expected owner node: %(expected_node)s. "
+                "Current group state: %(group_state)s. "
+                "Current owner node: %(owner_node)s.")
+
+
+class ClusterGroupMigrationTimeOut(ClusterGroupMigrationFailed):
+    msg_fmt = _("Cluster group '%(group_name)s' migration "
+                "timed out after %(time_elapsed)0.3fs. ")
+
+
+class ClusterPropertyRetrieveFailed(ClusterException):
+    msg_fmt = _("Failed to retrieve a cluster property.")
+
+
+class ClusterPropertyListEntryNotFound(ClusterPropertyRetrieveFailed):
+    msg_fmt = _("The specified cluster property list does not contain "
+                "an entry named '%(property_name)s'")
+
+
+class ClusterPropertyListParsingError(ClusterPropertyRetrieveFailed):
+    msg_fmt = _("Parsing a cluster property list failed.")

--- a/os_win/tests/unit/test_base.py
+++ b/os_win/tests/unit/test_base.py
@@ -21,6 +21,10 @@ from six.moves import builtins
 from os_win import exceptions
 
 
+class TestingException(Exception):
+    pass
+
+
 class FakeWMIExc(exceptions.x_wmi):
     def __init__(self, hresult=None):
         excepinfo = [None] * 5 + [hresult]

--- a/os_win/tests/unit/utils/compute/test_clusterutils.py
+++ b/os_win/tests/unit/utils/compute/test_clusterutils.py
@@ -13,8 +13,11 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import ctypes
+
 import ddt
 import mock
+from six.moves import queue
 
 from os_win import constants
 from os_win import exceptions
@@ -286,30 +289,34 @@ class ClusterUtilsTestCase(test_base.OsWinBaseTestCase):
                                            self._FAKE_HOST,
                                            mock.sentinel.timeout)
 
-        exp_valid_transition_states = [constants.CLUSTER_GROUP_PENDING]
         mock_migrate_vm.assert_called_once_with(
             self._FAKE_VM_NAME, self._FAKE_HOST,
             self._clusterutils._LIVE_MIGRATION_TYPE,
             constants.CLUSTER_GROUP_ONLINE,
-            exp_valid_transition_states,
             mock.sentinel.timeout)
 
     @mock.patch.object(_clusapi_utils, 'DWORD')
     @mock.patch.object(clusterutils.ClusterUtils,
-                       '_wait_for_cluster_group_state')
+                       '_wait_for_cluster_group_migration')
+    @mock.patch.object(clusterutils.ClusterUtils,
+                       '_validate_migration')
+    @mock.patch.object(clusterutils,
+                       '_ClusterGroupStateChangeListener')
     @ddt.data(None, exceptions.ClusterException)
-    def test_migrate_vm(self, raised_exc, mock_wait_group, mock_dword):
-        mock_wait_group.side_effect = raised_exc
+    def test_migrate_vm(self, wait_unexpected_exc,
+                        mock_listener_cls,
+                        mock_validate_migr,
+                        mock_wait_group, mock_dword):
+        mock_wait_group.side_effect = wait_unexpected_exc
 
         migrate_args = (self._FAKE_VM_NAME,
                         self._FAKE_HOST,
                         self._clusterutils._LIVE_MIGRATION_TYPE,
                         constants.CLUSTER_GROUP_ONLINE,
-                        mock.sentinel.valid_transition_states,
                         mock.sentinel.timeout)
 
-        if raised_exc:
-            self.assertRaises(raised_exc,
+        if wait_unexpected_exc:
+            self.assertRaises(wait_unexpected_exc,
                               self._clusterutils._migrate_vm,
                               *migrate_args)
         else:
@@ -349,12 +356,22 @@ class ClusterUtilsTestCase(test_base.OsWinBaseTestCase):
             exp_clus_group_h, exp_clus_node_h, expected_migrate_flags,
             self._clusapi.get_property_list.return_value)
 
+        mock_listener_cls.assert_called_once_with(exp_clus_h,
+                                                  self._FAKE_VM_NAME)
+        mock_listener = mock_listener_cls.return_value
+
         mock_wait_group.assert_called_once_with(
+            mock_listener.__enter__.return_value,
             self._FAKE_VM_NAME, exp_clus_group_h,
             constants.CLUSTER_GROUP_ONLINE,
-            self._FAKE_HOST,
-            mock.sentinel.valid_transition_states,
             mock.sentinel.timeout)
+
+        if not wait_unexpected_exc:
+            mock_validate_migr.assert_called_once_with(
+                exp_clus_group_h,
+                self._FAKE_VM_NAME,
+                constants.CLUSTER_GROUP_ONLINE,
+                self._FAKE_HOST)
 
         self._clusapi.close_cluster_group.assert_called_once_with(
             exp_clus_group_h)
@@ -362,57 +379,356 @@ class ClusterUtilsTestCase(test_base.OsWinBaseTestCase):
             exp_clus_node_h)
         self._clusapi.close_cluster.assert_called_once_with(exp_clus_h)
 
-    @mock.patch.object(clusterutils._utils, 'time')
-    def test_wait_for_clus_group_state_failed(self, mock_time):
-        desired_host = self._FAKE_HOST
-        desired_state = constants.CLUSTER_GROUP_ONLINE
-        valid_transition_states = [constants.CLUSTER_GROUP_PENDING]
+    @mock.patch.object(clusterutils.ClusterUtils,
+                       '_cancel_cluster_group_migration')
+    @mock.patch.object(clusterutils.ClusterUtils,
+                       '_wait_for_cluster_group_migration')
+    @mock.patch.object(clusterutils.ClusterUtils,
+                       '_validate_migration')
+    @mock.patch.object(clusterutils,
+                       '_ClusterGroupStateChangeListener')
+    @ddt.data(True, False)
+    def test_migrate_vm_timeout(self, finished_after_cancel,
+                                mock_listener_cls,
+                                mock_validate_migr,
+                                mock_wait_group,
+                                mock_cancel_migr):
+        timeout_exc = exceptions.ClusterGroupMigrationTimeOut(
+            group_name=self._FAKE_VM_NAME,
+            time_elapsed=10)
+        mock_wait_group.side_effect = timeout_exc
+        mock_listener = mock_listener_cls.return_value.__enter__.return_value
+        mock_validate_migr.side_effect = (
+            (None, ) if finished_after_cancel
+            else exceptions.ClusterGroupMigrationFailed(
+                group_name=self._FAKE_VM_NAME,
+                expected_state=mock.sentinel.expected_state,
+                expected_node=self._FAKE_HOST,
+                group_state=mock.sentinel.expected_state,
+                owner_node=mock.sentinel.other_host))
 
-        group_states = [dict(owner_node=desired_host,
-                             state=constants.CLUSTER_GROUP_PENDING),
-                        dict(owner_node=desired_host,
-                             state=constants.CLUSTER_GROUP_FAILED)]
-        self._clusapi.get_cluster_group_state.side_effect = group_states
+        migrate_args = (self._FAKE_VM_NAME,
+                        self._FAKE_HOST,
+                        self._clusterutils._LIVE_MIGRATION_TYPE,
+                        mock.sentinel.exp_state,
+                        mock.sentinel.timeout)
 
-        # We don't want a timeout to be raised. We expect the tested
-        # function to force breaking the retry loop when the cluster
-        # group gets into a 'failed' state.
-        #
-        # As a precaution measure, we're still forcing a timeout at
-        # some point, to avoid an infinite loop if something goes wrong.
-        mock_time.time.side_effect = [0] * 10 + [100]
+        if finished_after_cancel:
+            self._clusterutils._migrate_vm(*migrate_args)
+        else:
+            self.assertRaises(exceptions.ClusterGroupMigrationTimeOut,
+                              self._clusterutils._migrate_vm,
+                              *migrate_args)
 
-        self.assertRaises(exceptions.InvalidClusterGroupState,
-                          self._clusterutils._wait_for_cluster_group_state,
-                          mock.sentinel.group_name,
-                          mock.sentinel.group_handle,
-                          desired_state,
-                          desired_host,
-                          valid_transition_states,
-                          timeout=10)
+        exp_clus_group_h = self._clusapi.open_cluster_group.return_value
+        mock_cancel_migr.assert_called_once_with(
+            mock_listener, self._FAKE_VM_NAME, exp_clus_group_h,
+            mock.sentinel.exp_state, mock.sentinel.timeout)
+        mock_validate_migr.assert_called_once_with(exp_clus_group_h,
+                                                   self._FAKE_VM_NAME,
+                                                   mock.sentinel.exp_state,
+                                                   self._FAKE_HOST)
 
-        self._clusapi.get_cluster_group_state.assert_has_calls(
-            [mock.call(mock.sentinel.group_handle)] * len(group_states))
-
-    @mock.patch.object(clusterutils._utils, 'time')
-    def test_wait_for_clus_group_state_success(self, mock_time):
-        desired_host = self._FAKE_HOST
-        desired_state = constants.CLUSTER_GROUP_ONLINE
-
-        group_state = dict(owner_node=desired_host.upper(),
-                           state=desired_state)
+    @ddt.data({},
+              {'expected_state': constants.CLUSTER_GROUP_OFFLINE,
+               'is_valid': False},
+              {'expected_node': 'some_other_node',
+               'is_valid': False})
+    @ddt.unpack
+    def test_validate_migration(
+            self, expected_node=_FAKE_HOST,
+            expected_state=constants.CLUSTER_GROUP_ONLINE,
+            is_valid=True):
+        group_state = dict(owner_node=self._FAKE_HOST.upper(),
+                           state=constants.CLUSTER_GROUP_ONLINE)
         self._clusapi.get_cluster_group_state.return_value = group_state
 
-        self._clusterutils._wait_for_cluster_group_state(
-            mock.sentinel.group_name,
-            mock.sentinel.group_handle,
-            desired_state,
-            desired_host,
-            [],
-            timeout=10)
+        if is_valid:
+            self._clusterutils._validate_migration(mock.sentinel.group_handle,
+                                                   self._FAKE_VM_NAME,
+                                                   expected_state,
+                                                   expected_node)
+        else:
+            self.assertRaises(exceptions.ClusterGroupMigrationFailed,
+                              self._clusterutils._validate_migration,
+                              mock.sentinel.group_handle,
+                              self._FAKE_VM_NAME,
+                              expected_state,
+                              expected_node)
 
         self._clusapi.get_cluster_group_state.assert_called_once_with(
             mock.sentinel.group_handle)
+
+    @mock.patch.object(clusterutils.ClusterUtils,
+                       '_cancel_cluster_group_migration')
+    @mock.patch.object(clusterutils,
+                       '_ClusterGroupStateChangeListener')
+    def test_cancel_cluster_group_migration_public(self, mock_listener_cls,
+                                                   mock_cancel_migr):
+
+        exp_clus_h = self._clusapi.open_cluster.return_value
+        exp_clus_group_h = self._clusapi.open_cluster_group.return_value
+
+        mock_listener = mock_listener_cls.return_value
+        mock_listener.__enter__.return_value = mock_listener
+
+        self._clusterutils.cancel_cluster_group_migration(
+            mock.sentinel.group_name,
+            mock.sentinel.expected_state,
+            mock.sentinel.timeout)
+
+        self._clusapi.open_cluster.assert_called_once_with()
+        self._clusapi.open_cluster_group.assert_called_once_with(
+            exp_clus_h, mock.sentinel.group_name)
+
+        mock_listener.__enter__.assert_called_once_with()
+        mock_listener_cls.assert_called_once_with(exp_clus_h,
+                                                  mock.sentinel.group_name)
+        mock_cancel_migr.assert_called_once_with(
+            mock_listener,
+            mock.sentinel.group_name,
+            exp_clus_group_h,
+            mock.sentinel.expected_state,
+            mock.sentinel.timeout)
+
+        self._clusapi.close_cluster.assert_called_once_with(exp_clus_h)
+        self._clusapi.close_cluster_group.assert_called_once_with(
+            exp_clus_group_h)
+
+    @mock.patch.object(clusterutils.ClusterUtils,
+                       '_get_cluster_group_state')
+    @mock.patch.object(clusterutils.ClusterUtils,
+                       '_is_migration_pending')
+    @mock.patch.object(clusterutils.ClusterUtils,
+                       '_wait_for_cluster_group_migration')
+    @ddt.data({},
+              {'cancel_exception': test_base.TestingException()},
+              {'cancel_exception':
+                  exceptions.Win32Exception(
+                      error_code=_clusapi_utils.INVALID_HANDLE_VALUE,
+                      func_name=mock.sentinel.func_name,
+                      error_message=mock.sentinel.error_message)},
+              {'cancel_exception':
+                  exceptions.Win32Exception(
+                      error_code=_clusapi_utils.ERROR_INVALID_STATE,
+                      func_name=mock.sentinel.func_name,
+                      error_message=mock.sentinel.error_message),
+               'invalid_state_for_cancel': True},
+              {'cancel_exception':
+                  exceptions.Win32Exception(
+                      error_code=_clusapi_utils.ERROR_INVALID_STATE,
+                      func_name=mock.sentinel.func_name,
+                      error_message=mock.sentinel.error_message),
+               'invalid_state_for_cancel': True,
+               'cancel_still_pending': True},
+              {'cancel_still_pending': True},
+              {'cancel_still_pending': True,
+               'cancel_wait_exception': test_base.TestingException()})
+    @ddt.unpack
+    def test_cancel_cluster_group_migration(self, mock_wait_migr,
+                                            mock_is_migr_pending,
+                                            mock_get_gr_state,
+                                            cancel_still_pending=False,
+                                            cancel_exception=None,
+                                            invalid_state_for_cancel=False,
+                                            cancel_wait_exception=None):
+        expected_exception = None
+        if cancel_wait_exception:
+            expected_exception = exceptions.JobTerminateFailed()
+        if (cancel_exception and (not invalid_state_for_cancel
+                                  or cancel_still_pending)):
+            expected_exception = cancel_exception
+
+        mock_is_migr_pending.return_value = cancel_still_pending
+        mock_get_gr_state.return_value = dict(
+            state=mock.sentinel.state,
+            status_info=mock.sentinel.status_info)
+
+        self._clusapi.cancel_cluster_group_operation.side_effect = (
+            cancel_exception or (not cancel_still_pending, ))
+        mock_wait_migr.side_effect = cancel_wait_exception
+
+        cancel_args = (mock.sentinel.listener,
+                       mock.sentinel.group_name,
+                       mock.sentinel.group_handle,
+                       mock.sentinel.expected_state,
+                       mock.sentinel.timeout)
+        if expected_exception:
+            self.assertRaises(
+                expected_exception.__class__,
+                self._clusterutils._cancel_cluster_group_migration,
+                *cancel_args)
+        else:
+            self._clusterutils._cancel_cluster_group_migration(
+                *cancel_args)
+
+        self._clusapi.cancel_cluster_group_operation.assert_called_once_with(
+            mock.sentinel.group_handle)
+
+        if isinstance(cancel_exception, exceptions.Win32Exception):
+            mock_get_gr_state.assert_called_once_with(
+                mock.sentinel.group_handle)
+            mock_is_migr_pending.assert_called_once_with(
+                mock.sentinel.state,
+                mock.sentinel.status_info,
+                mock.sentinel.expected_state)
+        if cancel_still_pending and not cancel_exception:
+            mock_wait_migr.assert_called_once_with(
+                mock.sentinel.listener,
+                mock.sentinel.group_name,
+                mock.sentinel.group_handle,
+                mock.sentinel.expected_state,
+                timeout=mock.sentinel.timeout)
+
+    def test_is_migration_pending(self):
+        self.assertTrue(
+            self._clusterutils._is_migration_pending(
+                group_state=constants.CLUSTER_GROUP_OFFLINE,
+                group_status_info=0,
+                expected_state=constants.CLUSTER_GROUP_ONLINE))
+        self.assertTrue(
+            self._clusterutils._is_migration_pending(
+                group_state=constants.CLUSTER_GROUP_ONLINE,
+                group_status_info=_clusapi_utils.
+                    CLUSGRP_STATUS_WAITING_IN_QUEUE_FOR_MOVE | 1,  # noqa
+                expected_state=constants.CLUSTER_GROUP_ONLINE))
+        self.assertFalse(
+            self._clusterutils._is_migration_pending(
+                group_state=constants.CLUSTER_GROUP_OFFLINE,
+                group_status_info=0,
+                expected_state=constants.CLUSTER_GROUP_OFFLINE))
+
+    @mock.patch.object(clusterutils.ClusterUtils, '_is_migration_pending')
+    @mock.patch.object(clusterutils.ClusterUtils, '_get_cluster_group_state')
+    @mock.patch.object(clusterutils, 'time')
+    def test_wait_for_clus_group_migr_timeout(self, mock_time,
+                                              mock_get_gr_state,
+                                              mock_is_migr_pending):
+        exp_wait_iterations = 3
+        mock_listener = mock.Mock()
+        mock_time.time.side_effect = range(exp_wait_iterations + 2)
+        timeout = 10
+
+        state_info = dict(state=mock.sentinel.current_state,
+                          status_info=mock.sentinel.status_info)
+
+        events = [dict(status_info=mock.sentinel.migr_queued),
+                  dict(state=mock.sentinel.pending_state),
+                  queue.Empty]
+
+        mock_get_gr_state.return_value = state_info
+        mock_is_migr_pending.return_value = True
+        mock_listener.get.side_effect = events
+
+        self.assertRaises(
+            exceptions.ClusterGroupMigrationTimeOut,
+            self._clusterutils._wait_for_cluster_group_migration,
+            mock_listener,
+            mock.sentinel.group_name,
+            mock.sentinel.group_handle,
+            mock.sentinel.expected_state,
+            timeout=timeout)
+
+        mock_get_gr_state.assert_called_once_with(mock.sentinel.group_handle)
+
+        exp_wait_times = [timeout - elapsed - 1
+                          for elapsed in range(exp_wait_iterations)]
+        mock_listener.get.assert_has_calls(
+            [mock.call(wait_time) for wait_time in exp_wait_times])
+        mock_is_migr_pending.assert_has_calls(
+            [mock.call(mock.sentinel.current_state,
+                       mock.sentinel.status_info,
+                       mock.sentinel.expected_state),
+             mock.call(mock.sentinel.current_state,
+                       mock.sentinel.migr_queued,
+                       mock.sentinel.expected_state),
+             mock.call(mock.sentinel.pending_state,
+                       mock.sentinel.migr_queued,
+                       mock.sentinel.expected_state)])
+
+    @mock.patch.object(clusterutils.ClusterUtils, '_is_migration_pending')
+    @mock.patch.object(clusterutils.ClusterUtils, '_get_cluster_group_state')
+    def test_wait_for_clus_group_migr_success(self, mock_get_gr_state,
+                                              mock_is_migr_pending):
+        mock_listener = mock.Mock()
+
+        state_info = dict(state=mock.sentinel.current_state,
+                          status_info=mock.sentinel.status_info)
+
+        mock_get_gr_state.return_value = state_info
+        mock_is_migr_pending.side_effect = [True, False]
+        mock_listener.get.return_value = {}
+
+        self._clusterutils._wait_for_cluster_group_migration(
+            mock_listener,
+            mock.sentinel.group_name,
+            mock.sentinel.group_handle,
+            mock.sentinel.expected_state,
+            timeout=None)
+
+        mock_listener.get.assert_called_once_with(None)
+
+    @mock.patch.object(clusterutils.ClusterUtils,
+                       '_get_cluster_group_state')
+    @mock.patch.object(clusterutils.ClusterUtils,
+                       '_is_migration_queued')
+    def test_get_cluster_group_state_info(self, mock_is_migr_queued,
+                                          mock_get_gr_state):
+
+        exp_clus_h = self._clusapi.open_cluster.return_value
+        exp_clus_group_h = self._clusapi.open_cluster_group.return_value
+
+        mock_get_gr_state.return_value = dict(
+            state=mock.sentinel.state,
+            status_info=mock.sentinel.status_info,
+            owner_node=mock.sentinel.owner_node)
+
+        sts_info = self._clusterutils.get_cluster_group_state_info(
+            mock.sentinel.group_name)
+        exp_sts_info = dict(state=mock.sentinel.state,
+                            owner_node=mock.sentinel.owner_node,
+                            migration_queued=mock_is_migr_queued.return_value)
+
+        self.assertEqual(exp_sts_info, sts_info)
+
+        self._clusapi.open_cluster.assert_called_once_with()
+        self._clusapi.open_cluster_group.assert_called_once_with(
+            exp_clus_h, mock.sentinel.group_name)
+
+        mock_get_gr_state.assert_called_once_with(exp_clus_group_h)
+        mock_is_migr_queued.assert_called_once_with(mock.sentinel.status_info)
+
+        self._clusapi.close_cluster.assert_called_once_with(exp_clus_h)
+        self._clusapi.close_cluster_group.assert_called_once_with(
+            exp_clus_group_h)
+
+    @mock.patch('ctypes.byref')
+    def test_get_cluster_group_state(self, mock_byref):
+        mock_byref.side_effect = lambda x: ('byref', x)
+
+        state_info = dict(state=mock.sentinel.state,
+                          owner_node=mock.sentinel.owner_node)
+        self._clusapi.get_cluster_group_state.return_value = state_info
+
+        self._clusapi.cluster_group_control.return_value = (
+            mock.sentinel.buff, mock.sentinel.buff_sz)
+        self._clusapi.get_cluster_group_status_info.return_value = (
+            mock.sentinel.status_info)
+
+        exp_state_info = state_info.copy()
+        exp_state_info['status_info'] = mock.sentinel.status_info
+
+        ret_val = self._clusterutils._get_cluster_group_state(
+            mock.sentinel.group_handle)
+        self.assertEqual(exp_state_info, ret_val)
+
+        self._clusapi.get_cluster_group_state.assert_called_once_with(
+            mock.sentinel.group_handle)
+        self._clusapi.cluster_group_control.assert_called_once_with(
+            mock.sentinel.group_handle,
+            _clusapi_utils.CLUSCTL_GROUP_GET_RO_COMMON_PROPERTIES)
+        self._clusapi.get_cluster_group_status_info.assert_called_once_with(
+            mock_byref(mock.sentinel.buff), mock.sentinel.buff_sz)
 
     @mock.patch.object(clusterutils, 'tpool')
     @mock.patch.object(clusterutils, 'patcher')
@@ -451,3 +767,244 @@ class ClusterUtilsTestCase(test_base.OsWinBaseTestCase):
         fake_callback.assert_called_once_with(self._FAKE_VM_NAME,
                                               self._FAKE_PREV_HOST,
                                               self._FAKE_HOST)
+
+
+class ClusterEventListenerTestCase(test_base.OsWinBaseTestCase):
+    @mock.patch.object(clusterutils._ClusterEventListener, '_setup')
+    def setUp(self, mock_setup):
+        super(ClusterEventListenerTestCase, self).setUp()
+
+        self._listener = clusterutils._ClusterEventListener(
+            mock.sentinel.cluster_handle,
+            mock.sentinel.notif_filters_list)
+
+        self._listener._clusapi_utils = mock.Mock()
+        self._clusapi = self._listener._clusapi_utils
+
+    def test_get_notif_key_dw(self):
+        fake_notif_key = 1
+        notif_key_dw = self._listener._get_notif_key_dw(fake_notif_key)
+
+        self.assertIsInstance(notif_key_dw, ctypes.c_ulong)
+        self.assertEqual(fake_notif_key, notif_key_dw.value)
+        self.assertEqual(notif_key_dw,
+                         self._listener._get_notif_key_dw(fake_notif_key))
+
+    @mock.patch.object(clusterutils._ClusterEventListener,
+                       '_get_notif_key_dw')
+    def test_add_filter(self, mock_get_notif_key):
+        mock_get_notif_key.side_effect = (
+            mock.sentinel.notif_key_dw,
+            mock.sentinel.notif_key_dw_2)
+        self._clusapi.create_cluster_notify_port_v2.return_value = (
+            mock.sentinel.notif_port_h)
+
+        self._listener._add_filter(mock.sentinel.filter,
+                                   mock.sentinel.notif_key)
+        self._listener._add_filter(mock.sentinel.filter_2,
+                                   mock.sentinel.notif_key_2)
+
+        self.assertEqual(mock.sentinel.notif_port_h,
+                         self._listener._notif_port_h)
+        mock_get_notif_key.assert_has_calls(
+            [mock.call(mock.sentinel.notif_key),
+             mock.call(mock.sentinel.notif_key_2)])
+        self._clusapi.create_cluster_notify_port_v2.assert_has_calls(
+            [mock.call(mock.sentinel.cluster_handle,
+                       mock.sentinel.filter,
+                       None,
+                       mock.sentinel.notif_key_dw),
+             mock.call(mock.sentinel.cluster_handle,
+                       mock.sentinel.filter_2,
+                       mock.sentinel.notif_port_h,
+                       mock.sentinel.notif_key_dw_2)])
+
+    @mock.patch.object(clusterutils._ClusterEventListener, '_add_filter')
+    @mock.patch.object(_clusapi_utils, 'NOTIFY_FILTER_AND_TYPE')
+    def test_setup_notif_port(self, mock_filter_struct_cls, mock_add_filter):
+        notif_filter = dict(object_type=mock.sentinel.object_type,
+                            filter_flags=mock.sentinel.filter_flags,
+                            notif_key=mock.sentinel.notif_key)
+        self._listener._notif_filters_list = [notif_filter]
+
+        self._listener._setup_notif_port()
+
+        mock_filter_struct_cls.assert_called_once_with(
+            dwObjectType=mock.sentinel.object_type,
+            FilterFlags=mock.sentinel.filter_flags)
+        mock_add_filter.assert_called_once_with(
+            mock_filter_struct_cls.return_value,
+            mock.sentinel.notif_key)
+
+    def test_signal_stopped(self):
+        self._listener._running = True
+
+        self._listener._signal_stopped()
+
+        self.assertFalse(self._listener._running)
+        self.assertIsNone(self._listener._event_queue.get(block=False))
+
+    @mock.patch.object(clusterutils._ClusterEventListener,
+                       '_signal_stopped')
+    def test_stop(self, mock_signal_stopped):
+        self._listener._notif_port_h = mock.sentinel.notif_port_h
+
+        self._listener.stop()
+
+        mock_signal_stopped.assert_called_once_with()
+        self._clusapi.close_cluster_notify_port.assert_called_once_with(
+            mock.sentinel.notif_port_h)
+
+    @mock.patch.object(clusterutils._ClusterEventListener,
+                       '_process_event')
+    def test_listen(self, mock_process_event):
+        events = [mock.sentinel.ignored_event, mock.sentinel.retrieved_event]
+        self._clusapi.get_cluster_notify_v2.side_effect = events
+
+        self._listener._running = True
+        self._listener._notif_port_h = mock.sentinel.notif_port_h
+
+        def fake_process_event(event):
+            if event == mock.sentinel.ignored_event:
+                return
+
+            self._listener._running = False
+            return mock.sentinel.processed_event
+
+        mock_process_event.side_effect = fake_process_event
+
+        self._listener._listen()
+
+        processed_event = self._listener._event_queue.get(block=False)
+        self.assertEqual(mock.sentinel.processed_event,
+                         processed_event)
+        self.assertTrue(self._listener._event_queue.empty())
+
+        self._clusapi.get_cluster_notify_v2.assert_any_call(
+            mock.sentinel.notif_port_h,
+            timeout_ms=-1)
+
+    def test_listen_exception(self):
+        self._listener._running = True
+
+        self._clusapi.get_cluster_notify_v2.side_effect = (
+            test_base.TestingException)
+
+        self._listener._listen()
+
+        self.assertFalse(self._listener._running)
+
+    def test_get_event(self):
+        self._listener._running = True
+        self._listener._event_queue = mock.Mock()
+
+        event = self._listener.get(timeout=mock.sentinel.timeout)
+        self.assertEqual(self._listener._event_queue.get.return_value, event)
+
+        self._listener._event_queue.get.assert_called_once_with(
+            timeout=mock.sentinel.timeout)
+
+    def test_get_event_listener_stopped(self):
+        self.assertRaises(exceptions.OSWinException,
+                          self._listener.get,
+                          timeout=1)
+
+        def fake_get(block=True, timeout=0):
+            self._listener._running = False
+            return None
+
+        self._listener._running = True
+        self._listener._event_queue = mock.Mock(get=fake_get)
+
+        self.assertRaises(exceptions.OSWinException,
+                          self._listener.get,
+                          timeout=1)
+
+    @mock.patch.object(clusterutils._ClusterEventListener,
+                       '_ensure_listener_running')
+    @mock.patch.object(clusterutils._ClusterEventListener,
+                       'stop')
+    def test_context_manager(self, mock_stop, mock_ensure_running):
+        with self._listener as l:
+            self.assertIs(self._listener, l)
+            mock_ensure_running.assert_called_once_with()
+
+        mock_stop.assert_called_once_with()
+
+
+class ClusterGroupStateChangeListenerTestCase(test_base.OsWinBaseTestCase):
+    _FAKE_GROUP_NAME = 'fake_group_name'
+
+    @mock.patch.object(clusterutils._ClusterEventListener, '_setup')
+    def setUp(self, mock_setup):
+        super(ClusterGroupStateChangeListenerTestCase, self).setUp()
+
+        self._listener = clusterutils._ClusterGroupStateChangeListener(
+            mock.sentinel.cluster_handle,
+            self._FAKE_GROUP_NAME)
+
+        self._listener._clusapi_utils = mock.Mock()
+        self._clusapi = self._listener._clusapi_utils
+
+    def _get_fake_event(self, **kwargs):
+        event = dict(cluster_object_name=self._FAKE_GROUP_NAME.upper(),
+                     object_type=mock.sentinel.object_type,
+                     filter_flags=mock.sentinel.filter_flags,
+                     buff=mock.sentinel.buff,
+                     buff_sz=mock.sentinel.buff_sz)
+        event.update(**kwargs)
+        return event
+
+    def _get_exp_processed_event(self, event, **kwargs):
+        preserved_keys = ['cluster_object_name', 'object_type',
+                          'filter_flags', 'notif_key']
+        exp_proc_evt = {key: event[key] for key in preserved_keys}
+        exp_proc_evt.update(**kwargs)
+        return exp_proc_evt
+
+    @mock.patch('ctypes.byref')
+    def test_process_event_dropped(self, mock_byref):
+        event = self._get_fake_event(cluster_object_name='other_group_name')
+        self.assertIsNone(self._listener._process_event(event))
+
+        event = self._get_fake_event(notif_key=2)
+        self.assertIsNone(self._listener._process_event(event))
+
+        notif_key = self._listener._NOTIF_KEY_GROUP_COMMON_PROP
+        self._clusapi.get_cluster_group_status_info.side_effect = (
+            exceptions.ClusterPropertyListEntryNotFound(
+                property_name='fake_prop_name'))
+        event = self._get_fake_event(notif_key=notif_key)
+        self.assertIsNone(self._listener._process_event(event))
+
+    def test_process_state_change_event(self):
+        fake_state = constants.CLUSTER_GROUP_ONLINE
+        event_buff = ctypes.c_ulong(fake_state)
+        notif_key = self._listener._NOTIF_KEY_GROUP_STATE
+
+        event = self._get_fake_event(notif_key=notif_key,
+                                     buff=ctypes.byref(event_buff),
+                                     buff_sz=ctypes.sizeof(event_buff))
+        exp_proc_evt = self._get_exp_processed_event(
+            event, state=fake_state)
+
+        proc_evt = self._listener._process_event(event)
+        self.assertEqual(exp_proc_evt, proc_evt)
+
+    @mock.patch('ctypes.byref')
+    def test_process_status_info_change_event(self, mock_byref):
+        self._clusapi.get_cluster_group_status_info.return_value = (
+            mock.sentinel.status_info)
+        mock_byref.side_effect = lambda x: ('byref', x)
+        notif_key = self._listener._NOTIF_KEY_GROUP_COMMON_PROP
+
+        event = self._get_fake_event(notif_key=notif_key)
+        exp_proc_evt = self._get_exp_processed_event(
+            event, status_info=mock.sentinel.status_info)
+
+        proc_evt = self._listener._process_event(event)
+        self.assertEqual(exp_proc_evt, proc_evt)
+
+        self._clusapi.get_cluster_group_status_info.assert_called_once_with(
+            mock_byref(mock.sentinel.buff),
+            mock.sentinel.buff_sz)


### PR DESCRIPTION
We incorrectly assumed that the group state will immediately become
'Pending' when a migration is requested, judging by the expected
'ErrorPending' return code of the move function.

This is not the case, as the group can be reported as 'Online' while
being on the source node, before a live migration is actually
performed successfully. This is incorrectly treated as an exception
at the moment.

This change refactors the way in which we check pending migrations.
We rely on cluster group state change events in this matter.

In case of migration timeouts, we're now attempting to cancel pending
migrations.

Also, some of the private methods functionality is now publicly
exposed (e.g. canceling migrations, detecting queued migrations).

In the future, we're planning to implement a custom cluster resource
dll, having a finer control over this.

Closes-Bug: #1628938

Change-Id: I6c268355213718d4d66e0e77a89c558cde3213b6
(cherry picked from commit e09f672e228379dbeeebad4156891ddb75a06769)